### PR TITLE
fix: return unsubscribe functions to clean up

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,6 @@
 	"useTabs": true,
 	"singleQuote": true,
 	"trailingComma": "none",
-	"printWidth": 100
+	"printWidth": 100,
+	"endOfLine": "auto"
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # `sk-lanyard` (SvelteKit + Lanyard)
+
 SvelteKit integration with [Lanyard](https://github.com/Phineas/lanyard), an API to fetch your Discord presence.
 
 `sk-lanyard` is fully typed and supports the entire Lanyard API, using both REST and WebSockets.
@@ -6,10 +7,11 @@ SvelteKit integration with [Lanyard](https://github.com/Phineas/lanyard), an API
 The `useLanyard` function returns a reactive store containing presence data.
 
 ## [Demo](https://stackblitz.com/edit/sk-lanyard-demo?file=src/routes/index.svelte)
+
 ```html
 <script>
-    import { useLanyard } from 'sk-lanyard';
-    const presence = useLanyard({ method: 'rest', id: '524722785302609941' })
+	import { useLanyard } from 'sk-lanyard';
+	const presence = useLanyard({ method: 'rest', id: '524722785302609941' });
 </script>
 
 <pre>
@@ -19,6 +21,7 @@ The `useLanyard` function returns a reactive store containing presence data.
 ```
 
 ## Usage
+
 ```ts
 import { useLanyard } from 'sk-lanyard';
 
@@ -27,48 +30,55 @@ import type { LanyardData, LanyardHello } from 'sk-lanyard';
 ```
 
 ### REST
+
 ```ts
 // Use the REST API to fetch a single user
-const lanyard = useLanyard({ method: 'rest', id: '524722785302609941'});
+const lanyard = useLanyard({ method: 'rest', id: '524722785302609941' });
 ```
+
 ```ts
 // Use an interval of 1000 ms
-const lanyard = useLanyard({ 
-    method: 'rest',
-    pollInterval: 1000,
-    id: '524722785302609941'
+const lanyard = useLanyard({
+	method: 'rest',
+	pollInterval: 1000,
+	id: '524722785302609941'
 });
 ```
+
 ```ts
 // Use a custom endpoint
-const lanyard = useLanyard({ 
-    method: 'rest',
-    restUrl: 'https://lanyard.example.com/rest',
-    id: '524722785302609941'
+const lanyard = useLanyard({
+	method: 'rest',
+	restUrl: 'https://lanyard.example.com/rest',
+	id: '524722785302609941'
 });
 ```
 
 ### WebSockets
+
 ```ts
 // Use the WebSockets API to subscribe to a single user
-const lanyard = useLanyard({ method: 'ws', id: '524722785302609941'});
+const lanyard = useLanyard({ method: 'ws', id: '524722785302609941' });
 ```
+
 ```ts
 // Subscribe to multiple users
-const lanyard = useLanyard({ 
-    method: 'ws',
-    ids: ['524722785302609941', '299707523370319883']
+const lanyard = useLanyard({
+	method: 'ws',
+	ids: ['524722785302609941', '299707523370319883']
 });
 ```
+
 ```ts
 // Subscribe to all users tracked by Lanyard
 const lanyard = useLanyard({ method: 'ws', all: true });
 ```
+
 ```ts
 // Use a custom endpoint
-const lanyard = useLanyard({ 
-    method: 'ws',
-    wsUrl: 'wss://lanyard.example.com/ws',
-    id: '524722785302609941'
+const lanyard = useLanyard({
+	method: 'ws',
+	wsUrl: 'wss://lanyard.example.com/ws',
+	id: '524722785302609941'
 });
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,162 +1,161 @@
 import { Readable, readable, Subscriber } from 'svelte/store';
 import {
-    LanyardConfig,
-    LanyardConfigAll,
-    LanyardConfigMany,
-    LanyardConfigOne,
-    LanyardConfigRest,
-    LanyardConfigWS
+	LanyardConfig,
+	LanyardConfigAll,
+	LanyardConfigMany,
+	LanyardConfigOne,
+	LanyardConfigRest,
+	LanyardConfigWS
 } from './configTypes';
 import { LanyardData, LanyardResponse } from './restTypes';
 import {
-    InitState,
-    LanyardEvent,
-    LanyardHeartbeat,
-    LanyardHello,
-    LanyardInitialize,
-    LanyardMessage,
-    LanyardOpcode
+	InitState,
+	LanyardEvent,
+	LanyardHeartbeat,
+	LanyardHello,
+	LanyardInitialize,
+	LanyardMessage,
+	LanyardOpcode
 } from './wsTypes';
 
 const DEFAULT_REST_URL = 'https://api.lanyard.rest/v1';
 const DEFAULT_WS_URL = 'wss://api.lanyard.rest/socket';
 
 export function useLanyard(
-    config: LanyardConfigMany | LanyardConfigAll
+	config: LanyardConfigMany | LanyardConfigAll
 ): Readable<Record<string, LanyardData>>;
 export function useLanyard(config: LanyardConfigRest | LanyardConfigOne): Readable<LanyardData>;
 export function useLanyard(config: LanyardConfig) {
-    if (config.method === 'rest') {
-        const store = readable<LanyardData>(undefined, (set) => {
-            lanyardRest(config, set);
-        });
-        return store;
-    }
-    if (config.method === 'ws') {
-        if ('id' in config) {
-            const store = readable<LanyardData>(undefined, (set) => {
-                lanyardWS(config, set);
-            });
-            return store;
-        }
-        const store = readable<Record<string, LanyardData>>(undefined, (set) => {
-            lanyardWS(config, set);
-        });
-        return store;
-    }
+	if (config.method === 'rest') {
+		const store = readable<LanyardData>(undefined, (set) => {
+			lanyardRest(config, set);
+		});
+		return store;
+	}
+	if (config.method === 'ws') {
+		if ('id' in config) {
+			const store = readable<LanyardData>(undefined, (set) => {
+				lanyardWS(config, set);
+			});
+			return store;
+		}
+		const store = readable<Record<string, LanyardData>>(undefined, (set) => {
+			lanyardWS(config, set);
+		});
+		return store;
+	}
 }
 
 async function lanyardRest(config: LanyardConfigRest, set: Subscriber<LanyardData>) {
-    if (typeof window === 'undefined') {
-        return;
-    }
+	if (typeof window === 'undefined') {
+		return;
+	}
 
-    const restUrl = config.restUrl ?? DEFAULT_REST_URL;
-    const lanyardFetch = async () =>
-        (await fetch(`${restUrl}/users/${config.id}`).then((res) =>
-            res.json()
-        )) as Promise<LanyardResponse>;
-    const updateStore = async () => {
-        const res = await lanyardFetch();
-        if (res.success) {
-            set(res.data);
-        } else {
-            throw new Error(res.error.message);
-        }
-    };
-    updateStore();
-    setInterval(updateStore, config.pollInterval ?? 5000);
+	const restUrl = config.restUrl ?? DEFAULT_REST_URL;
+	const lanyardFetch = async () =>
+		(await fetch(`${restUrl}/users/${config.id}`).then((res) =>
+			res.json()
+		)) as Promise<LanyardResponse>;
+	const updateStore = async () => {
+		const res = await lanyardFetch();
+		if (res.success) {
+			set(res.data);
+		} else {
+			throw new Error(res.error.message);
+		}
+	};
+	updateStore();
+	setInterval(updateStore, config.pollInterval ?? 5000);
 }
 
 async function lanyardWS<T extends InitState>(config: LanyardConfigWS, set: Subscriber<T>) {
-    if (typeof window === 'undefined') {
-        return;
-    }
+	if (typeof window === 'undefined') {
+		return;
+	}
 
-    const wsUrl = config.wsUrl ?? DEFAULT_WS_URL;
-    const ws = new WebSocket(wsUrl);
+	const wsUrl = config.wsUrl ?? DEFAULT_WS_URL;
+	const ws = new WebSocket(wsUrl);
 
-    const send = <T>(message: T) => ws.send(JSON.stringify(message));
-    const recv = (callback: (this: WebSocket, event: MessageEvent<string>) => unknown) => {
-        ws.addEventListener('message', callback);
-    };
-    const once = <T>() =>
-        new Promise<T>((res) => {
-            const fn: (this: WebSocket, event: MessageEvent<string>) => unknown = (event) => {
-                ws.removeEventListener('message', fn);
-                res(JSON.parse(event.data));
-            };
-            ws.addEventListener('message', fn);
-        });
-    const waitInit = () =>
-        new Promise<void>((res, rej) => {
-            const open = () => {
-                ws.removeEventListener('open', open);
-                res();
-            };
-            ws.addEventListener('open', open);
+	const send = <T>(message: T) => ws.send(JSON.stringify(message));
+	const recv = (callback: (this: WebSocket, event: MessageEvent<string>) => unknown) => {
+		ws.addEventListener('message', callback);
+	};
+	const once = <T>() =>
+		new Promise<T>((res) => {
+			const fn: (this: WebSocket, event: MessageEvent<string>) => unknown = (event) => {
+				ws.removeEventListener('message', fn);
+				res(JSON.parse(event.data));
+			};
+			ws.addEventListener('message', fn);
+		});
+	const waitInit = () =>
+		new Promise<void>((res, rej) => {
+			const open = () => {
+				ws.removeEventListener('open', open);
+				res();
+			};
+			ws.addEventListener('open', open);
 
-            const err = () => {
-                ws.removeEventListener('error', err);
-                rej();
-            };
-            ws.addEventListener('error', err);
-        });
+			const err = () => {
+				ws.removeEventListener('error', err);
+				rej();
+			};
+			ws.addEventListener('error', err);
+		});
 
-    await waitInit();
+	await waitInit();
 
-    if ('all' in config) {
-        send<LanyardInitialize>({
-            op: LanyardOpcode.INITIALIZE,
-            d: {
-                subscribe_to_all: true
-            }
-        });
-    }
-    if ('ids' in config) {
-        send<LanyardInitialize>({
-            op: LanyardOpcode.INITIALIZE,
-            d: {
-                subscribe_to_ids: config.ids
-            }
-        });
-    }
-    if ('id' in config) {
-        send<LanyardInitialize>({
-            op: LanyardOpcode.INITIALIZE,
-            d: {
-                subscribe_to_id: config.id
-            }
-        });
-    }
-    const hello = await once<LanyardHello>();
-    const heartbeatInterval = hello.d.heartbeat_interval;
+	if ('all' in config) {
+		send<LanyardInitialize>({
+			op: LanyardOpcode.INITIALIZE,
+			d: {
+				subscribe_to_all: true
+			}
+		});
+	}
+	if ('ids' in config) {
+		send<LanyardInitialize>({
+			op: LanyardOpcode.INITIALIZE,
+			d: {
+				subscribe_to_ids: config.ids
+			}
+		});
+	}
+	if ('id' in config) {
+		send<LanyardInitialize>({
+			op: LanyardOpcode.INITIALIZE,
+			d: {
+				subscribe_to_id: config.id
+			}
+		});
+	}
+	const hello = await once<LanyardHello>();
+	const heartbeatInterval = hello.d.heartbeat_interval;
 
-    const heartbeat = () => {
-        send<LanyardHeartbeat>({
-            op: LanyardOpcode.HEARTBEAT,
-            d: undefined
-        });
-    };
-    setInterval(heartbeat, heartbeatInterval);
+	const heartbeat = () => {
+		send<LanyardHeartbeat>({
+			op: LanyardOpcode.HEARTBEAT,
+			d: undefined
+		});
+	};
+	setInterval(heartbeat, heartbeatInterval);
 
-    const init = await once<LanyardMessage<T>>();
-    const state = init.d;
-    set(state);
+	const init = await once<LanyardMessage<T>>();
+	const state = init.d;
+	set(state);
 
-    recv((event) => {
-        const update: LanyardEvent<'PRESENCE_UPDATE'> = JSON.parse(event.data);
-        if ('user_id' in update.d) {
-            const { user_id, ...data } = update.d;
-            (state as Record<string, LanyardData>)[update.d.user_id] = data;
-            set(state);
-        } else {
-            set({ ...update.d } as T);
-        }
-    });
+	recv((event) => {
+		const update: LanyardEvent<'PRESENCE_UPDATE'> = JSON.parse(event.data);
+		if ('user_id' in update.d) {
+			const { user_id, ...data } = update.d;
+			(state as Record<string, LanyardData>)[update.d.user_id] = data;
+			set(state);
+		} else {
+			set({ ...update.d } as T);
+		}
+	});
 }
 
 export * from './configTypes';
 export * from './restTypes';
 export * from './wsTypes';
-

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,6 +142,8 @@ function lanyardWS<T extends InitState>(config: LanyardConfigWS, set: Subscriber
 		recv((event) => {
 			const update: LanyardEvent<'PRESENCE_UPDATE'> = JSON.parse(event.data);
 			if ('user_id' in update.d) {
+				// user_id is removed from the object
+				// eslint-disable-next-line @typescript-eslint/no-unused-vars
 				const { user_id, ...data } = update.d;
 				(state as Record<string, LanyardData>)[update.d.user_id] = data;
 				set(state);

--- a/src/restTypes.ts
+++ b/src/restTypes.ts
@@ -1,79 +1,79 @@
 export interface LanyardSuccessResponse {
-    success: true;
-    data: LanyardData;
+	success: true;
+	data: LanyardData;
 }
 export interface LanyardErrorResponse {
-    success: false;
-    error: LanyardError;
+	success: false;
+	error: LanyardError;
 }
 
 export type LanyardResponse = LanyardSuccessResponse | LanyardErrorResponse;
 
 export interface LanyardError {
-    message: string;
-    code: string;
+	message: string;
+	code: string;
 }
 
 export interface LanyardData {
-    active_on_discord_mobile: boolean;
-    active_on_discord_desktop: boolean;
-    listening_to_spotify: boolean;
-    kv: KV;
-    spotify: Spotify;
-    discord_user: DiscordUser;
-    discord_status: string;
-    activities: Activity[];
+	active_on_discord_mobile: boolean;
+	active_on_discord_desktop: boolean;
+	listening_to_spotify: boolean;
+	kv: KV;
+	spotify: Spotify;
+	discord_user: DiscordUser;
+	discord_status: string;
+	activities: Activity[];
 }
 
 export interface Activity {
-    type: number;
-    timestamps: Timestamps;
-    sync_id?: string;
-    state: string;
-    session_id?: string;
-    party?: Party;
-    name: string;
-    id: string;
-    flags?: number;
-    details: string;
-    created_at: number;
-    assets: Assets;
-    application_id?: string;
+	type: number;
+	timestamps: Timestamps;
+	sync_id?: string;
+	state: string;
+	session_id?: string;
+	party?: Party;
+	name: string;
+	id: string;
+	flags?: number;
+	details: string;
+	created_at: number;
+	assets: Assets;
+	application_id?: string;
 }
 
 export interface Assets {
-    large_text: string;
-    large_image: string;
-    small_text?: string;
-    small_image?: string;
+	large_text: string;
+	large_image: string;
+	small_text?: string;
+	small_image?: string;
 }
 
 export interface Party {
-    id: string;
+	id: string;
 }
 
 export interface Timestamps {
-    start: number;
-    end?: number;
+	start: number;
+	end?: number;
 }
 
 export interface DiscordUser {
-    username: string;
-    public_flags: number;
-    id: string;
-    discriminator: string;
-    avatar: string;
+	username: string;
+	public_flags: number;
+	id: string;
+	discriminator: string;
+	avatar: string;
 }
 
 export interface KV {
-    location: string;
+	location: string;
 }
 
 export interface Spotify {
-    track_id: string;
-    timestamps: Timestamps;
-    song: string;
-    artist: string;
-    album_art_url: string;
-    album: string;
+	track_id: string;
+	timestamps: Timestamps;
+	song: string;
+	artist: string;
+	album_art_url: string;
+	album: string;
 }


### PR DESCRIPTION
## Changes

This PR makes a few changes:

1. Fixes formatting with Prettier because `.prettierrc` uses tabs but a few files used spaces.
2. Returns unsubscribe functions from both the REST and WebSocket methods.
  a. REST function returns a `clearInterval` callback with the poll timer.
  b. WebSocket function has been made synchronous to return a `ws.close` callback. Async functionality was moved to a `.then` clause after `waitInit`.
  c. The `useLanyard` function was changed to return those corresponding callbacks.
3. Added an ESLint ignore for the `user_id` restructuring to remove lint warnings.